### PR TITLE
Fix for using the charset UTF-8 when reading the resources file

### DIFF
--- a/src/main/java/it/burning/cron/CronExpressionDescriptor.java
+++ b/src/main/java/it/burning/cron/CronExpressionDescriptor.java
@@ -4,11 +4,14 @@ import it.burning.cron.CronExpressionParser.Day;
 import it.burning.cron.CronExpressionParser.Month;
 import it.burning.cron.CronExpressionParser.Options;
 import it.burning.utils.RxReplace;
+import it.burning.utils.UTF8Control;
 
-import java.util.Calendar;
-import java.util.Locale;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -81,7 +84,7 @@ public class CronExpressionDescriptor {
         this.options = options;
         this.use24HourTimeFormat = options.use24HourTimeFormat();
         this.locale = options.getLocale();
-        this.localization = ResourceBundle.getBundle(LOCALIZATION_BUNDLE, this.locale);
+        this.localization = ResourceBundle.getBundle(LOCALIZATION_BUNDLE, this.locale, new UTF8Control());
     }
 
     public Options getOptions() {
@@ -139,7 +142,7 @@ public class CronExpressionDescriptor {
         this.options = options;
         this.use24HourTimeFormat = options.use24HourTimeFormat();
         this.locale = options.getLocale();
-        this.localization = ResourceBundle.getBundle(LOCALIZATION_BUNDLE, this.locale);
+        this.localization = ResourceBundle.getBundle(LOCALIZATION_BUNDLE, this.locale, new UTF8Control());
     }
 
     //endregion
@@ -180,7 +183,7 @@ public class CronExpressionDescriptor {
         this.options = options;
         this.use24HourTimeFormat = options.use24HourTimeFormat();
         this.locale = options.getLocale();
-        this.localization = ResourceBundle.getBundle(LOCALIZATION_BUNDLE, this.locale);
+        this.localization = ResourceBundle.getBundle(LOCALIZATION_BUNDLE, this.locale, new UTF8Control());
     }
 
     /**

--- a/src/main/java/it/burning/utils/UTF8Control.java
+++ b/src/main/java/it/burning/utils/UTF8Control.java
@@ -1,0 +1,42 @@
+package it.burning.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+public class UTF8Control extends ResourceBundle.Control {
+    public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IOException {
+        // The below is a copy of the default implementation.
+        String bundleName = toBundleName(baseName, locale);
+        String resourceName = toResourceName(bundleName, "properties");
+        ResourceBundle bundle = null;
+        InputStream stream = null;
+        if (reload) {
+            URL url = loader.getResource(resourceName);
+            if (url != null) {
+                URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(false);
+                    stream = connection.getInputStream();
+                }
+            }
+        } else {
+            stream = loader.getResourceAsStream(resourceName);
+        }
+        if (stream != null) {
+            try {
+                // Only this line is changed to make it to read properties files as UTF-8.
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
+            } finally {
+                stream.close();
+            }
+        }
+        return bundle;
+    }
+}

--- a/src/test/java/it/burning/cron/CronExpressionDescriptorTest.java
+++ b/src/test/java/it/burning/cron/CronExpressionDescriptorTest.java
@@ -146,5 +146,29 @@ class CronExpressionDescriptorTest {
         assertEquals("Every 10 minutes, starting at 5 minutes past the hour", CronExpressionDescriptor.getDescription("5/10 * * * *"));
         assertEquals("Every 10 hours, starting at 01:00", CronExpressionDescriptor.getDescription("0 1/10 * * *"));
 
+        CronExpressionDescriptor.setDefaultLocale(Locale.forLanguageTag("pt"));
+        assertEquals("Às 12:00", CronExpressionDescriptor.getDescription("0 0 12 * * ?"));
+        assertEquals("Às 10:15", CronExpressionDescriptor.getDescription("0 15 10 ? * *"));
+        assertEquals("Às 10:15", CronExpressionDescriptor.getDescription("0 15 10 * * ?"));
+        assertEquals("Às 10:15", CronExpressionDescriptor.getDescription("0 15 10 * * ? *"));
+        assertEquals("Às 10:15, somente em 2005", CronExpressionDescriptor.getDescription("0 15 10 * * ? 2005"));
+        assertEquals("A cada minuto, entre 14:00 e 14:59", CronExpressionDescriptor.getDescription("0 * 14 * * ?"));
+        assertEquals("A cada 5 minutos, entre 14:00 e 14:59", CronExpressionDescriptor.getDescription("0 0/5 14 * * ?"));
+        assertEquals("A cada 5 minutos, Às 14:00 e 18:00", CronExpressionDescriptor.getDescription("0 0/5 14,18 * * ?"));
+        assertEquals("A cada minuto entre 14:00 e 14:05", CronExpressionDescriptor.getDescription("0 0-5 14 * * ?"));
+        assertEquals("Aos 10 e 44 minutos da hora, Às 14:00, somente de Quarta-feira, somente em Março", CronExpressionDescriptor.getDescription("0 10,44 14 ? 3 WED"));
+        assertEquals("Às 10:15, de Segunda-feira a Sexta-feira", CronExpressionDescriptor.getDescription("0 15 10 ? * MON-FRI"));
+        assertEquals("Às 10:15, no dia 15 do mês", CronExpressionDescriptor.getDescription("0 15 10 15 * ?"));
+        assertEquals("Às 10:15, no último dia do mês", CronExpressionDescriptor.getDescription("0 15 10 L * ?"));
+        assertEquals("Às 10:15, 2 dias antes do último dia do mês", CronExpressionDescriptor.getDescription("0 15 10 L-2 * ?"));
+        assertEquals("Às 10:15, na última Sexta-feira do mês", CronExpressionDescriptor.getDescription("0 15 10 ? * 6L"));
+        assertEquals("Às 10:15, na última Sexta-feira do mês, de 2002 a 2005", CronExpressionDescriptor.getDescription("0 15 10 ? * 6L 2002-2005"));
+        assertEquals("Às 10:15, on the terceira Sexta-feira do mês", CronExpressionDescriptor.getDescription("0 15 10 ? * 6#3"));
+        assertEquals("Às 15:00, no dia 10 do mês, somente de Sábado", CronExpressionDescriptor.getDescription("0 15 10 * 6"));
+        assertEquals("Às 12:00, a cada 5 dias", CronExpressionDescriptor.getDescription("0 0 12 1/5 * ?"));
+        assertEquals("Às 11:11, no dia 11 do mês, somente em Novembro", CronExpressionDescriptor.getDescription("0 11 11 11 11 ?"));
+        assertEquals("A cada 10 minutos, iniciando aos 5 minutos da hora", CronExpressionDescriptor.getDescription("5/10 * * * *"));
+        assertEquals("A cada 10 horas, iniciando Às 01:00", CronExpressionDescriptor.getDescription("0 1/10 * * *"));
+
     }
 }


### PR DESCRIPTION
I'm creating this PR to solve the issue reported in #3. I was facing the same issue here but with the locale pt_BR.

[Before]
![Screenshot from 2022-05-17 16-39-43](https://user-images.githubusercontent.com/3975090/168896315-2fdf39f8-4e9f-4027-b0c2-0bf7c8370e1d.png)
